### PR TITLE
update fluid/CMakeLists.txt for case-sensitive Mac

### DIFF
--- a/fluid/CMakeLists.txt
+++ b/fluid/CMakeLists.txt
@@ -41,7 +41,7 @@ set(CPPFILES
 )
 
 if(APPLE AND NOT OPTION_APPLE_X11)
-    set(FLUID_ICON "${CMAKE_CURRENT_SOURCE_DIR}/Fluid.app/Contents/Resources/fluid.icns")
+    set(FLUID_ICON "${CMAKE_CURRENT_SOURCE_DIR}/fluid.app/Contents/Resources/fluid.icns")
     add_executable(fluid MACOSX_BUNDLE ${CPPFILES} "${FLUID_ICON}")
     FLTK_SET_BUNDLE_ICON(fluid "${FLUID_ICON}")
 else()


### PR DESCRIPTION
If you set your Mac case-sensitive, cmake will fail. It should be 'fluid.app', not 'Fluid.app'